### PR TITLE
Move generateRandomTileMap to a utility class for generating maps

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -3,6 +3,7 @@ import { TextureParameters } from "../utils/TextureManager";
 import TextureManager from "../utils/TextureManager";
 import TilemapManager from "../utils/TilemapManager";
 import Assets from "../assets";
+import MapGenerator from "../utils/MapGenerator";
 
 class PlayScene extends Phaser.Scene {
 	constructor() {
@@ -29,27 +30,11 @@ class PlayScene extends Phaser.Scene {
 			Assets.Textures.EMPTY_TILE,
 		]);
 
-		const arr = this.generateRandomTilemap(Assets.MapWidth, Assets.MapHeight);
+		const arr = MapGenerator.generateMap(Assets.MapWidth, Assets.MapHeight);
 		tilemap.populateTilemap("layer", arr);
 	}
 
 	update() {}
-
-	generateRandomTilemap(width: number, height: number): TextureParameters[][] {
-		const map: TextureParameters[][] = [];
-		for (let y = 0; y < height; y++) {
-			const row: TextureParameters[] = [];
-			for (let x = 0; x < width; x++) {
-				const tile =
-					Math.random() < 0.5
-						? Assets.Textures.FILLED_TILE
-						: Assets.Textures.EMPTY_TILE;
-				row.push(tile);
-			}
-			map.push(row);
-		}
-		return map;
-	}
 }
 
 export default PlayScene;

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -30,7 +30,12 @@ class PlayScene extends Phaser.Scene {
 			Assets.Textures.EMPTY_TILE,
 		]);
 
-		const arr = MapGenerator.generateMap(Assets.MapWidth, Assets.MapHeight);
+		const arr = MapGenerator.generateMap(
+			Assets.MapWidth,
+			Assets.MapHeight,
+			Assets.Textures.FILLED_TILE,
+			Assets.Textures.EMPTY_TILE,
+		);
 		tilemap.populateTilemap("layer", arr);
 	}
 

--- a/src/utils/MapGenerator.ts
+++ b/src/utils/MapGenerator.ts
@@ -1,19 +1,22 @@
+import { TextureParameters } from "./TextureManager";
 class MapGenerator {
-  static generateMap(width: number, height: number): TextureParameters[][] {
-    const map: TextureParameters[][] = [];
-    for (let y = 0; y < height; y++) {
-      const row: TextureParameters[] = [];
-      for (let x = 0; x < width; x++) {
-        const tile =
-          Math.random() < 0.5
-            ? Assets.Textures.FILLED_TILE
-            : Assets.Textures.EMPTY_TILE;
-        row.push(tile);
-      }
-      map.push(row);
-    }
-    return map;
-  }
+	static generateMap(
+		width: number,
+		height: number,
+		filled: TextureParameters,
+		empty: TextureParameters,
+	): TextureParameters[][] {
+		const map: TextureParameters[][] = [];
+		for (let y = 0; y < height; y++) {
+			const row: TextureParameters[] = [];
+			for (let x = 0; x < width; x++) {
+				const tile = Math.random() < 0.5 ? filled : empty;
+				row.push(tile);
+			}
+			map.push(row);
+		}
+		return map;
+	}
 }
 
 export default MapGenerator;

--- a/src/utils/MapGenerator.ts
+++ b/src/utils/MapGenerator.ts
@@ -1,0 +1,19 @@
+class MapGenerator {
+  static generateMap(width: number, height: number): TextureParameters[][] {
+    const map: TextureParameters[][] = [];
+    for (let y = 0; y < height; y++) {
+      const row: TextureParameters[] = [];
+      for (let x = 0; x < width; x++) {
+        const tile =
+          Math.random() < 0.5
+            ? Assets.Textures.FILLED_TILE
+            : Assets.Textures.EMPTY_TILE;
+        row.push(tile);
+      }
+      map.push(row);
+    }
+    return map;
+  }
+}
+
+export default MapGenerator;


### PR DESCRIPTION
Related to #4

Move the `generateRandomTilemap` method to a utility class and rename it to `generateMap`.

* Add a new file `src/utils/MapGenerator.ts` with a `MapGenerator` class containing a static `generateMap` method.
* Move the logic from `generateRandomTilemap` to the `generateMap` method in the `MapGenerator` class.
* Modify `src/scenes/PlayScene.ts` to import the `MapGenerator` class and use the `generateMap` method instead of `generateRandomTilemap`.
* Remove the `generateRandomTilemap` method from the `PlayScene` class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/ai-game-template/pull/5?shareId=973cebd4-4ba0-4484-baed-f2786fc818d0).